### PR TITLE
Bugfix for input data file names

### DIFF
--- a/default_options.yaml
+++ b/default_options.yaml
@@ -14,7 +14,8 @@ data:
   #
   # filename (mandatory):
   # Full or relative path to filename containing MPAS data you wish to plot. Can be a single file,
-  # a glob-able regex pattern match (e.g. /path/to/nc/data/*.nc), or a list of files
+  # a glob-able regex pattern match (e.g. /path/to/nc/data/*.nc), a list of files, or a list of
+  # glob-able regex pattern matches.
   # 
   # gridfile:
   # Some MPAS files (usually "diag" files) do not contain grid information; in these cases you

--- a/plot_mpas_netcdf.py
+++ b/plot_mpas_netcdf.py
@@ -12,6 +12,7 @@ import sys
 import time
 import traceback
 from multiprocessing import Pool
+from pprint import pprint, pformat
 
 print("Importing uxarray; this may take a while...")
 import uxarray as ux
@@ -521,15 +522,28 @@ if __name__ == "__main__":
     # Load settings from config file
     expt_config=setup_config(logger,args.config)
 
-    if os.path.isfile(expt_config["data"]["filename"]):
-        files = [expt_config["data"]["filename"]]
-    elif glob.glob(expt_config["data"]["filename"]):
-        files = sorted(glob.glob(expt_config["data"]["filename"]))
-    elif isinstance(expt_config["data"]["filename"], list):
-        files = expt_config["data"]["filename"]
-    else:
-        raise FileNotFoundError(f"Invalid filename(s) specified:\n{expt_config['data']['filename']}")
+    # Generate list of explicit file paths from the possibly globbed list
+    # of file patterns specified in the config file.
+    filename = expt_config["data"]["filename"]
+    if not isinstance(filename, list):
+        filename = [filename]
 
+    files = []
+    for f in filename:
+        if os.path.isfile(f):
+            files.append(f)
+        else:
+            f_expanded = sorted(glob.glob(f))
+            if f_expanded:
+                files = files + f_expanded
+            else:
+                raise FileNotFoundError(f"Invalid filename(s) specified:\n{f}")
+
+    # Keep only unique elements in file list.
+    files = sorted(list(set(files)))
+
+    logger.info(f"Set of data files to plot is:")
+    logger.info(pformat(files))
     if not expt_config["data"].get("gridfile"):
         expt_config["data"]["gridfile"]=""
 


### PR DESCRIPTION
Currently, if a **list** of data file paths (as opposed to a string) is specified in the config file, the script will crash.  This PR fixes that bug.  It also allows either a glob-able string or a list of glob-able strings to be specified as the (set of) input data files in the config file.

This was tested in a few different ways.