### PR TITLE
Adding new custom colormap capability, lakes, other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ INFO:root:Plotting first time step
 
 It may take some time to produce plots, depending on the size of your domain and number of fields plotted.
 
+## Custom colormaps
+Some custom colormaps have been set up to mimic the typical way of displaying certain data. These colormaps are specified in YAML format files in the `colormaps/` subdirectory.
+These custom colormaps may overwrite some user settings from `config_plot.yaml`, so if you want different settings you will have to modify the files there.
+
+For example, `colormaps/radar_refl.yaml` is designed to mimic the typical display scheme for radar reflectivity data, so the following settings are included:
+
+```
+vmin: 5
+vmax: 75
+plot_under: False
+```
+
+This limits the color range to data between 5 and 75 (dBz), and `plot_under: False` specifies that data below vmin (5) should not be plotted at all; data above vmax (75) will be
+plotted if present but will have the same color value as 75.
+
 ## Limitations
 
 This plotting utility is in a very early form, and has several known limitations:

--- a/colormaps/radar_refl.yaml
+++ b/colormaps/radar_refl.yaml
@@ -1,0 +1,20 @@
+vmin: 5
+vmax: 75
+plot_under: False
+colors:
+ - "#9C9C9C"
+ - "#767676"
+ - "#AAAAFF"
+ - "#8C8CEE"
+ - "#7070C9"
+ - "#00FB90"
+ - "#00BB00"
+ - "#FFFF70"
+ - "#D0D060"
+ - "#FF6060"
+ - "#DA0000"
+ - "#AE0000"
+ - "#0000FF"
+ - "#FFFFFF"
+ - "#E700FF"
+

--- a/config_plot.yaml.example
+++ b/config_plot.yaml.example
@@ -1,8 +1,8 @@
 # This is an example configure file; for additional documentation and a list of all available options, see default_options.yaml
 
 data:
-  filename: /scratch1/BMC/hmtb/kavulich/MPAS/plotting_scripts/DTC_fork/mpas_app/ush/plotting/history.2023-09-15_09.00.00.nc
-#  gridfile: /scratch1/BMC/hmtb/kavulich/MPAS/plotting_scripts/DTC_fork/mpas_app/ush/plotting/history.2023-09-15_09.00.00.nc
+  filename: /glade/work/kavulich/MPAS/tutorial/120km_global/rundir/history.2025-05-13_00.00.00.nc
+#  gridfile: /glade/work/kavulich/MPAS/tutorial/120km_global/rundir/history.2025-05-13_00.00.00.nc
   var:
     - qv
   lev:

--- a/config_plot.yaml.example
+++ b/config_plot.yaml.example
@@ -1,3 +1,5 @@
+# This is an example configure file; for additional documentation and a list of all available options, see default_options.yaml
+
 data:
   filename: /scratch1/BMC/hmtb/kavulich/MPAS/plotting_scripts/DTC_fork/mpas_app/ush/plotting/history.2023-09-15_09.00.00.nc
 #  gridfile: /scratch1/BMC/hmtb/kavulich/MPAS/plotting_scripts/DTC_fork/mpas_app/ush/plotting/history.2023-09-15_09.00.00.nc
@@ -19,20 +21,25 @@ plot:
   title:
     text: 'Plot of {varln}, level {lev} for MPAS forecast, {date} {time}'
     fontsize: 8
-  edges:
-    color: black
-    width: 0.1
   colorbar:
     orientation: vertical
     label: 'Units: {units}'
     fontsize: 8
+  boundaries:
+    detail: 0
+    scale: '50m'
+    color: 'black'
+
+  coastlines:
+    color: 'black'
+    linewidth: 0.5
   # Colormap for output from Matplotlib. Reference: https://matplotlib.org/stable/gallery/color/colormap_reference.html
   colormap: "viridis"
   dpi: 300
   figheight: 4
   figwidth: 8
   projection:
-    projection: Mercator
+    projection: PlateCarree
     latrange:
       - 10
       - 45

--- a/default_options.yaml
+++ b/default_options.yaml
@@ -162,8 +162,17 @@ plot:
   coastlines:
     enable: True
     # Scale is the resolution of the plotted boundary dataset. Options are 110m, 50m, and 10m.
+    scale: '10m'
+    color: 'blue'
+    facecolor: 'lightblue'
+    linewidth: 0.5
+
+  # Settings for plotting lakes.
+  lakes:
+    enable: False
+    # Scale is the resolution of the plotted boundary dataset. Options are 110m, 50m, and 10m.
     scale: '50m'
-    color: 'black'
+    color: 'blue'
     linewidth: 0.5
 
   # Settings for the plot's color bar

--- a/default_options.yaml
+++ b/default_options.yaml
@@ -146,8 +146,10 @@ plot:
     color: face
     width: 0.1
 
-  # Settings for plotting political boundaries. To disable political boundaries, specify "boundaries:" with no options
+  # Settings for plotting political boundaries. Settings scale, color, linewidth can either be a value (to apply to all boundaries)
+  # or a list of values to apply to the specific level 0, 1, or two boundaries described below
   boundaries:
+    enable: True
     # Level of political boundaries to plot. Level 0 is national boundaries, Level 1 is sub-national boundaries (e.g.
     # states, provinces, etc.), Level 2 is county boundaries (US only); counties require 10m scale
     detail: 0
@@ -155,8 +157,9 @@ plot:
     scale: '50m'
     color: 'black'
 
-  # Settings for plotting coastlines. To disable coastlines, specify "coastlines:" with no options
+  # Settings for plotting coastlines.
   coastlines:
+    enable: True
     # Scale is the resolution of the plotted boundary dataset. Options are 110m, 50m, and 10m.
     scale: '10m'
     # Most standard Matplotlib arguments for shapes will work here, but I haven't figured out good documentation on which.
@@ -175,7 +178,7 @@ plot:
     #
     # fontsize:
     # Font size for the colobar label.
-
+    enable: True
     orientation: vertical
     label: 'Units: {units}'
     fontsize: 8

--- a/default_options.yaml
+++ b/default_options.yaml
@@ -163,8 +163,7 @@ plot:
     enable: True
     # Scale is the resolution of the plotted boundary dataset. Options are 110m, 50m, and 10m.
     scale: '10m'
-    color: 'blue'
-    facecolor: 'lightblue'
+    color: 'black'
     linewidth: 0.5
 
   # Settings for plotting lakes.
@@ -172,7 +171,7 @@ plot:
     enable: False
     # Scale is the resolution of the plotted boundary dataset. Options are 110m, 50m, and 10m.
     scale: '50m'
-    color: 'blue'
+    color: 'black'
     linewidth: 0.5
 
   # Settings for the plot's color bar

--- a/default_options.yaml
+++ b/default_options.yaml
@@ -15,7 +15,7 @@ data:
   # filename (mandatory):
   # Full or relative path to filename containing MPAS data you wish to plot. Can be a single file,
   # a glob-able regex pattern match (e.g. /path/to/nc/data/*.nc), or a list of files
-  # 
+  #
   # gridfile:
   # Some MPAS files (usually "diag" files) do not contain grid information; in these cases you
   # must specify a "gridfile" that contains the grid information for the script to read
@@ -24,7 +24,7 @@ data:
   #
   # var:
   # Variable name to plot. Can be a list of variable names, or the string "all" (default).
-  # 
+  #
   # lev: Variable level to plot (for variables with multiple vertical levels). Can be a list of
   # level numbers, or the string "all". Default is level 1.
 
@@ -66,7 +66,7 @@ plot:
   # format:
   # The image format of the output, if not specified in the filename. See matplotlib documentation for valid options:
   # https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.savefig.html#matplotlib.pyplot.savefig
-  # 
+  #
   # title:
   # Settings controlling the title of the output plot(s) that will appear in the image above the plotted data.
   #   text:
@@ -77,23 +77,15 @@ plot:
   # exists:
   # Handle case when file exists. Valid options are
   #    overwrite  Overwrite existing file
-  #    abort      Raise exception
+  #    abort      Raise an exception
   #    rename     Rename the old file using the scheme {filename}-#.png, where # is the next available sequential integer
-  #
-  # periodic_bdy:
-  # For periodic domains (including global), the plot routines will ignore the periodic boundary by default.
-  # To plot all data, including boundaries, set this option, but it will slow down plotting substantially.
-  #
-  # colormap:
-  # Colormap for output from Matplotlib. Reference documentation for valid options:
-  # https://matplotlib.org/stable/gallery/color/colormap_reference.html
   #
   # dpi:
   # Image dots per inch
   #
   # figheight:
   # Image height in inches
-  # 
+  #
   # figwidth:
   # Image width in inches
 
@@ -114,10 +106,24 @@ plot:
     text: 'Plot of {varln}, level {lev} for MPAS forecast, {date} {time}'
     fontsize: 8
   exists: rename
-  colormap: "viridis"
   dpi: 300
   figheight: 4
   figwidth: 8
+
+  # colormap:
+  # Color scheme to use for output plots. Options can either be standard Matplotlib colormaps (reference
+  # https://matplotlib.org/stable/gallery/color/colormap_reference.html for valid options) or the name of
+  # a custom colormap under the colormaps/ directory (currently just one option: "radar_refl").
+  #
+  # NOTE: custom colormaps also include additional settings that will overwrite user config choices; see
+  # README.md for more information.
+  #
+  colormap: "viridis"
+
+  # periodic_bdy:
+  # For periodic domains (including global), the plot routines will omit the boundary cells by default. To plot
+  # all data, including boundaries, set this option to True, but note that it will slow down plotting substantially.
+  #
   periodic_bdy: False
 
   # vmin, vmax:
@@ -127,7 +133,7 @@ plot:
   vmin: null
   vmax: null
 
-  # :
+  # plot_under, plot_over:
   # By default any values above vmax or below vmin will be plotted as the color for vmax/vmin respectively.
   # To omit these out-of-range values all together, set plot_over/plot_under to False respectively.
 

--- a/default_options.yaml
+++ b/default_options.yaml
@@ -56,7 +56,7 @@ data:
   gridfile: ''
   var: all
   lev:
-    - 1
+    - 0
 
 # This section is for variables related to how the plot(s) is/are created.
 plot:
@@ -96,10 +96,6 @@ plot:
   # 
   # figwidth:
   # Image width in inches
-  # 
-  # vmin, vmax:
-  # By default the color range will be scaled to the max/min values of the plotted data. To use a custom range,
-  # set vmin and/or vmax
 
   # NOTE: for text fields such as filename, title, etc., some helpful variables are provided that
   # you can reference in the text string that will be substituted in the final output:
@@ -124,8 +120,19 @@ plot:
   figwidth: 8
   periodic_bdy: False
 
+  # vmin, vmax:
+  # By default the color range will be scaled to the max/min values of the plotted data. To use a custom range,
+  # set vmin and/or vmax
+
   vmin: null
   vmax: null
+
+  # :
+  # By default any values above vmax or below vmin will be plotted as the color for vmax/vmin respectively.
+  # To omit these out-of-range values all together, set plot_over/plot_under to False respectively.
+
+  plot_under: True
+  plot_over: True
 
   # Settings for plotting grid cell borders. To disable cell borders, set color="face" (colors the border the same as cell face)
   # or set width=0

--- a/default_options.yaml
+++ b/default_options.yaml
@@ -146,26 +146,24 @@ plot:
     color: face
     width: 0.1
 
-  # Settings for plotting political boundaries. Settings scale, color, linewidth can either be a value (to apply to all boundaries)
-  # or a list of values to apply to the specific level 0, 1, or two boundaries described below
+  # Settings for plotting political boundaries. Settings scale, color, linewidth can either be a single value (to apply to all boundaries)
+  # or a list of values to apply to the specific level 0, 1, or 2 boundaries described below
   boundaries:
     enable: True
     # Level of political boundaries to plot. Level 0 is national boundaries, Level 1 is sub-national boundaries (e.g.
     # states, provinces, etc.), Level 2 is county boundaries (US only); counties require 10m scale
     detail: 0
+    color: ['black','black','black']
+    linewidth: [0.2,0.2,0.2]
     # Scale is the resolution of the plotted boundary dataset. Options are 110m, 50m, and 10m.
-    scale: '50m'
-    color: 'black'
+    scale: ['50m','50m','50m']
 
   # Settings for plotting coastlines.
   coastlines:
     enable: True
     # Scale is the resolution of the plotted boundary dataset. Options are 110m, 50m, and 10m.
-    scale: '10m'
-    # Most standard Matplotlib arguments for shapes will work here, but I haven't figured out good documentation on which.
-    # The ones listed here work, but likely a lot more customization can happen here.
+    scale: '50m'
     color: 'black'
-    facecolor: 'none'
     linewidth: 0.5
 
   # Settings for the plot's color bar

--- a/plot_mpas_netcdf.py
+++ b/plot_mpas_netcdf.py
@@ -219,7 +219,7 @@ def plotit(logger,config_d: dict,uxds: ux.UxDataset,grid: ux.Grid,var: str,lev: 
     if config_d["plot"].get("lakes"):
         pl=config_d["plot"]["lakes"]
         if pl.get("enable"):
-            ax.add_feature(cfeature.NaturalEarthFeature(category='physical',edgecolor=pl["edgecolor"],facecolor='none',
+            ax.add_feature(cfeature.NaturalEarthFeature(category='physical',edgecolor=pl["color"],facecolor='none',
                            linewidth=pl["linewidth"], scale=pl["scale"], name='lakes'))
 
 

--- a/plot_mpas_netcdf.py
+++ b/plot_mpas_netcdf.py
@@ -189,29 +189,32 @@ def plotit(logger,config_d: dict,uxds: ux.UxDataset,grid: ux.Grid,var: str,lev: 
     if None not in [ config_d["plot"]["vmin"], config_d["plot"]["vmax"]]:
         pc.set_clim(config_d["plot"]["vmin"],config_d["plot"]["vmax"])
 
+    #Plot political boundaries if requested
+    if config_d["plot"].get("boundaries"):
+        pb=config_d["plot"]["boundaries"]
+        if pb.get("enable"):
+            # Users can set these values to scalars or lists; if scalar provided, re-format to list with three identical values
+            for setting in ["color", "linewidth", "scale"]:
+                if type(pb[setting]) is not list:
+
+                    pb[setting]=[pb[setting],pb[setting],pb[setting]]
+            if pb["detail"]==2:
+                ax.add_feature(cfeature.NaturalEarthFeature(category='cultural',
+                               scale=pb["scale"][2],edgecolor=pb["color"][2],
+                               facecolor='none',linewidth=pb["linewidth"][2], name='admin_2_counties'))
+            if pb["detail"]>0:
+                ax.add_feature(cfeature.NaturalEarthFeature(category='cultural',
+                               scale=pb["scale"][1],edgecolor=pb["color"][1],
+                               facecolor='none',linewidth=pb["linewidth"][1], name='admin_1_states_provinces'))
+            ax.add_feature(cfeature.NaturalEarthFeature(category='cultural',
+                           scale=pb["scale"][0],edgecolor=pb["color"][0],
+                           facecolor='none',linewidth=pb["linewidth"][0], name='admin_0_countries'))
     #Plot coastlines if requested
     if config_d["plot"].get("coastlines"):
-        if config_d["plot"]["coastlines"].get("enable"):
-            coastline_features=copy.copy(config_d["plot"]["coastlines"])
-            # Except for "enable", all keys of config_d["plot"]["coastlines"] are valid args to ax.add_feature, so
-            # this logic is simpler than passing every option individually
-            coastline_features.pop("enable")
-            ax.add_feature(cfeature.NaturalEarthFeature(category='physical',
-                           **coastline_features, name='coastline'))
-    if config_d["plot"].get("boundaries"):
-        if config_d["plot"]["boundaries"].get("enable"):
-            ax.add_feature(cfeature.NaturalEarthFeature(category='cultural',
-                           scale=config_d["plot"]["boundaries"]["scale"],edgecolor=config_d["plot"]["boundaries"]["color"],
-                           facecolor='none',linewidth=0.2, name='admin_0_countries'))
-            if config_d["plot"]["boundaries"]["detail"]>0:
-                ax.add_feature(cfeature.NaturalEarthFeature(category='cultural',
-                               scale=config_d["plot"]["boundaries"]["scale"],edgecolor=config_d["plot"]["boundaries"]["color"],
-                               facecolor='none',linewidth=0.2, name='admin_1_states_provinces'))
-            if config_d["plot"]["boundaries"]["detail"]==2:
-                ax.add_feature(cfeature.NaturalEarthFeature(category='cultural',
-                               scale=config_d["plot"]["boundaries"]["scale"],edgecolor=config_d["plot"]["boundaries"]["color"],
-                               facecolor='none',linewidth=0.2, name='admin_2_counties'))
-
+        pcl=config_d["plot"]["coastlines"]
+        if pcl.get("enable"):
+            ax.add_feature(cfeature.NaturalEarthFeature(category='physical',color=pcl["color"],facecolor='none',
+                           linewidth=pcl["linewidth"], scale=pcl["scale"], name='coastline'))
 
     # Create a dict of substitutable patterns to make string substitutions easier, and determine output filename
     patterns,outfile,fmt = set_patterns_and_outfile(logger,validfmts,var,lev,filepath,field,config_d["plot"])

--- a/plot_mpas_netcdf.py
+++ b/plot_mpas_netcdf.py
@@ -215,6 +215,13 @@ def plotit(logger,config_d: dict,uxds: ux.UxDataset,grid: ux.Grid,var: str,lev: 
         if pcl.get("enable"):
             ax.add_feature(cfeature.NaturalEarthFeature(category='physical',color=pcl["color"],facecolor='none',
                            linewidth=pcl["linewidth"], scale=pcl["scale"], name='coastline'))
+    #Plot lakes if requested
+    if config_d["plot"].get("lakes"):
+        pl=config_d["plot"]["lakes"]
+        if pl.get("enable"):
+            ax.add_feature(cfeature.NaturalEarthFeature(category='physical',edgecolor=pl["edgecolor"],facecolor='none',
+                           linewidth=pl["linewidth"], scale=pl["scale"], name='lakes'))
+
 
     # Create a dict of substitutable patterns to make string substitutions easier, and determine output filename
     patterns,outfile,fmt = set_patterns_and_outfile(logger,validfmts,var,lev,filepath,field,config_d["plot"])


### PR DESCRIPTION
This is the latest round of improvements I've made over the past few weeks to the plotting scripts

### New custom colormaps

Bill Gallus requested a way to display radar data that mimicked typical ways of viewing this data. I was able to find some old documentation on how radar colors should be displayed in [this old document](https://web.archive.org/web/20210325123349/https://www.roc.noaa.gov/WSR88D/PublicDocs/NewTechnology/B17_2620003W_draft.pdf), page 26...though strangely the "light blue" of typical radar displays there is swapped out for pink, which I fixed by swapping the red and blue values from that table for just those three ranges, resulting in a display that very nicely mimics traditional radar data displays:

<img width="1500" height="1200" alt="refl10cm_1km_0-10" src="https://github.com/user-attachments/assets/1372e093-43bc-42b4-9c4b-21253cfeee24" />

This custom colormap is defined in a new file `colormaps/radar_refl.yaml`; this subdirectory can contain arbitrary custom colormaps in the future as the need arises. These colormap files also include the capability to override settings from the user's config file, which is important for aligning the data values with the appropriate colors, as well as the lower cutoff of when data will be displayed for radar in particular. 

### New capabilities

 - New `lakes:` configuration option that controls the display of lakeshores
 - New `plot_under` and `plot_over` options that allow users to omit plotting any data below `vmin` or above `vmax`.

### Miscellaneous improvements
 - The default variable level is now `0` rather than `1`, which makes more sense
 - Enabling/disabling political boundaries, coastlines, and color bars is now done explicitly with an `enable:` option rather than potentially confusing YAML dictionary shenanigans
 - Settings for plotting political boundaries made more logical: now level 0 (countries) overlays level 1 (states/provinces) overlays level 2 (counties).
 - Better example settings in `config_plot.yaml.example`
 - Move some logic in main `plotit()` function into a subfunction for better organization.