### PR TITLE
Enhance README with detailed mpas_plot description

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ shell, you must configure conda manually.
 
 ```
 source setup_conda.sh
-conda activate mpas_plot
 ```
 
 # Running the plotting script
@@ -50,6 +49,9 @@ options:
 
 The config file is where you will specify all the various options for what you want to plot, including which files, variables, levels, etc you want to plot. To setup the script to use your specific options, you’ll need to create a configuration file (`config_plot.yaml`). An example file `config_plot.yaml.example` is provided for reference, and you can view all available options in the `default_options.yaml` file.
 
+Detailed examples of configuration files, with links to staged data on NCAR HPC (Capser/Derecho), are available here:
+https://github.com/dtcenter/mpas_plot/wiki/mpas_plot-config-examples-and-use-cases
+
 Once you have modified `config_plot.yaml` with all the settings you want, simply run the script:
 
 ```
@@ -67,7 +69,7 @@ INFO     Starting plotit() for var='precipw', lev=0
 ...
 ```
 
-It may take some time to produce plots, depending on the size of your domain and number of fields plotted.
+It may take some time to produce plots, depending on the size of your domain and number of fields plotted. For large numbers of plots, using the parallel capability (`python plot_mpas_netcdf.py -p #`) is highly
 
 ## Custom colormaps
 Some custom colormaps have been set up to mimic the typical way of displaying certain data. These colormaps are specified in YAML format files in the `colormaps/` subdirectory.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The plotting script is built with argparse, so you can see a summary of the argu
 $ python plot_mpas_netcdf.py -h
 usage: plot_mpas_netcdf.py [-h] [-c CONFIG] [-d] [-p PROCS]
 
-Script for plotting a custom field on the native MPAS grid from native NetCDF format files
+Script for producing plot files from MPAS input and/or output in native NetCDF format
 
 options:
   -h, --help            show this help message and exit

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+**mpas_plot is a python utility for easy, configurable plotting of native-grid output fields of the
+[Model for Prediction Across Scales (MPAS)](https://www.mmm.ucar.edu/models/mpas), with particular emphasis
+on bulk creation of large numbers of plots, especially for HPC applications. It was developed at the
+[Developmental Testbed Center](https://dtcenter.org/who-we-are), a collaborative partnership between the
+National Oceanic and Atmospheric Administration (NOAA), US Air Force, and the
+National Science Foundation (NSF) National Center for Atmospheric Research (NCAR). It is powered by the
+[UXarray python library](https://uxarray.readthedocs.io/en/latest/), a collaborative effort between Project Raijin,
+funded by an NSF EarthCube award between NSF NCAR and The Pennsylvania State University, and the SEATS project, funded
+by the Department of Energy.**
+
+
 This README contains instructions for using `mpas_plot` utilities, including setting up the environment
 
 For detailed examples of different plotting functions, see the GitHub wiki:

--- a/plot_mpas_netcdf.py
+++ b/plot_mpas_netcdf.py
@@ -623,7 +623,7 @@ if __name__ == "__main__":
 
     scriptstart = time.time()
     parser = argparse.ArgumentParser(
-        description="Script for plotting a custom field on the native MPAS grid from native NetCDF format files"
+        description="Script for producing plot files from MPAS input and/or output in native NetCDF format"
     )
     parser.add_argument('-c', '--config', type=str, default='config_plot.yaml',
                         help='File used to specify plotting options')


### PR DESCRIPTION
 - Added a detailed overview of the mpas_plot utility, its purpose, and its development background.
 - Remove unnecessary `conda activate` command
 - More details about parallel plotting, additional link to examples
 - Update script description for --help flag